### PR TITLE
FIX: when container re-starts, Neos cache should be cleared

### DIFF
--- a/container-files/build-typo3-neos/configure-typo3-neos.sh
+++ b/container-files/build-typo3-neos/configure-typo3-neos.sh
@@ -93,6 +93,12 @@ function install_typo3_neos() {
 
   log "Neos installed."
   cd $NEOS_ROOT
+  
+  # Make sure cache is cleared for all contexts. This is empty during the 1st container launch,
+  # but not clearing it when container re-starts can cause random issues.
+  rm -rf rm -rf Data/Temporary/*
+  
+  # Debug: show most recent git log messages
   git log -5 --pretty=format:"%h %an %cr: %s" --graph # Show most recent changes
   
   # If app is/was already installed, pull most recent code


### PR DESCRIPTION
When container starts for the 1st time, Data/Temporary folder is empty. But when it re-starts, it can contain cached data, which might cause problems with the rest of provision process.

For instance, container might re-start, but with fresh database backend. But Neos might have cached information, that database has been already provisioned.
