### PR TITLE
Make pre-installing the app to archive optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You start with creating a new Docker image based on **million12/typo3-flow-neos-
 #### Build phase
 
 During *build process* of your image, TYPO3 app will be pre-installed using `composer install` and embedded inside the image as a tar achive. Using ENV variables (listed below) you can customise pre-install process: provide custom distribution (e.g. from your GitHub repo) or specify different branch/tag. For detailed info about how this pre-install script works, see [pre-install-typo3-app.sh](container-files/build-typo3-app/pre-install-typo3-app.sh).
+It is posible to not use pre-installed app and compose app on first container start with setting `T3APP_PREINSTALL` variable to false (and not calling `RUN . /build-typo3-app/pre-install-typo3-app.sh` your image).
 
 In addition, if in the root directory of your project you have executable `build.sh` it will be executed as `build.sh --preinstall`. You can easily add custom build steps there which you want to run during Docker build phase. See `T3APP_USER_BUILD_SCRIPT` variable where you can customise path to that script.
 

--- a/container-files/build-typo3-app/include-variables.sh
+++ b/container-files/build-typo3-app/include-variables.sh
@@ -25,6 +25,7 @@ T3APP_NEOS_SITE_PACKAGE=${T3APP_NEOS_SITE_PACKAGE:=false}
 T3APP_NEOS_SITE_PACKAGE_FORCE_REIMPORT=${T3APP_NEOS_SITE_PACKAGE_FORCE_REIMPORT:=false}
 T3APP_ALWAYS_DO_PULL=${T3APP_ALWAYS_DO_PULL:=false}
 T3APP_FORCE_VHOST_CONF_UPDATE=${T3APP_FORCE_VHOST_CONF_UPDATE:=true}
+T3APP_PREINSTALL=${T3APP_PREINSTALL:=true}
 
 # Database ENV variables
 # Note: all DB_* variables are created by Docker when linking this container with MariaDB container (e.g. tutum/mariadb, million12/mariadb) with --link=mariadb-container-id:db option. 

--- a/container-files/build-typo3-app/pre-install-typo3-app.sh
+++ b/container-files/build-typo3-app/pre-install-typo3-app.sh
@@ -8,6 +8,9 @@
 # We do that to avoid installing TYPO3 app during the runtime, which 
 # can be slow and potentially error-prone (i.e. composer conflicts/timeouts etc).
 #
+# It is posible to not use pre-installed app and compose the app on first container
+# start with setting T3APP_PREINSTALL variable to false 
+# (and not calling RUN . /build-typo3-app/pre-install-typo3-app.sh your image).
 
 set -e
 set -u


### PR DESCRIPTION
Introduce `T3APP_PREINSTALL` variable, setting which to false would allow to bypass usage of pre-installed app and compose the app on first container launch.