### PR TITLE
Modify context setting matcher to only match if key is in the beginig

### DIFF
--- a/container-files/build-typo3-app/vhost.conf
+++ b/container-files/build-typo3-app/vhost.conf
@@ -5,8 +5,8 @@ server {
   index           index.php;
 
   set $context Production;
-  if ($host ~ dev)    { set $context Development; }
-  if ($host ~ behat)  { set $context $context/Behat; }
+  if ($host ~ \bdev\.)    { set $context Development; }
+  if ($host ~ \bbehat\.)  { set $context $context/Behat; }
 
   include /etc/nginx/conf.d/flow-rewrites.conf;
   include /etc/nginx/conf.d/flow-locations.conf;


### PR DESCRIPTION
Currently domain names like neos.dev get Dev context, while I would expect that to happen only for dev.neos.dev.
What do you think?