### PR TITLE
Only trigger `create_surf_directory_structure` during first setup

### DIFF
--- a/container-files/build-typo3-app/include-functions.sh
+++ b/container-files/build-typo3-app/include-functions.sh
@@ -49,10 +49,10 @@ function install_typo3_app() {
       log && log "Installing app (fresh install)..."
       clone_and_compose $APP_ROOT
     fi
-  fi
-  
-  if [ "${T3APP_USE_SURF_DEPLOYMENT^^}" = TRUE ]; then
-    create_surf_directory_structure
+    
+    if [ "${T3APP_USE_SURF_DEPLOYMENT^^}" = TRUE ]; then
+      create_surf_directory_structure
+    fi
   fi
 
   cd $APP_ROOT


### PR DESCRIPTION
`create_surf_directory_structure` should only be triggered once, during initial container start.
